### PR TITLE
Adds dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ typings/
 .dynamodb/
 data/users.db3
 *.db3
+
+# dotenv 
+.env

--- a/README.md
+++ b/README.md
@@ -51,5 +51,13 @@ Returns a data array containing information about all users (this includes passw
 ### Things I've learned along the way: 
 
 1. I failed to add my database file (with .db3 extension) to the gitignore at the beginning of the project, as a consequence it was added to the repo on github, which we don't want. 
+
 To fix this I stopped committing any changes to that file specifically, and made sure it was in the .gitignore file
+
 Finally, I cleared the cache (what does this do exactly?), which successfully ignored the db files in the project 
+
+2. Dotenv Package 
+
+When I initially deployed this API on heroku the build was successful, and when opening the App there was the "Up and running..." message of the / route's handler... but that was it. 
+
+Looking at past projects, that were deployed and used, I tried to track down what I did differently to get them to work. I noticed `dotenv` pretty quickly - a package I totally forgot about. 

--- a/data/connection.js
+++ b/data/connection.js
@@ -1,13 +1,11 @@
 const knex = require ('knex'); 
 
 //* Imports the knex configuration we built before
-const knexfile = require('../knexfile'); 
+const config = require('../knexfile'); 
 
 const environment = process.env.DB_ENV || 'development'; 
 
-const config = knexfile[environment]; 
-
-module.exports = knex(config); 
+module.exports = knex(config[environment]); 
 
 /* -------------------------------------------------------------------------- */
 /*                             About connection.js                            */

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 const server = require('./api/server'); 
-
-const port = process.env.PORT || 3000; 
+// * bringing dotenv in 
+require('dotenv').config(); 
+//* now switch this to the .env var, brought in by dotenv .config()
+const port = process.env.PORT; 
 
 server.listen(port, () => console.log(`Server running on ${port}`));

--- a/knexfile.js
+++ b/knexfile.js
@@ -70,3 +70,5 @@ module.exports = {
   }
 
 };
+
+//TODO heroku deployment not working... I think I need to update something here ... hmm 🤔

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/ashley-bergsma/leitspeed_api#readme",
   "dependencies": {
+    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "knex": "^0.21.13",
     "knex-cleaner": "^1.3.1",


### PR DESCRIPTION
Package dotenv added to the dependencies. Hoping that this will handle the environment server error I was having through Heroku.

The package handles assigning environment variables through a .env file (which is added to the .gitignore) it holds just one thing right now: The PORT number routed through the server.listen function.